### PR TITLE
Adding missing 'raise' keyword in population:update_positions method

### DIFF
--- a/customhys/population.py
+++ b/customhys/population.py
@@ -192,7 +192,7 @@ class Population:
 
         # Raise an error
         else:
-            PopulationError('Invalid update level')
+            raise PopulationError('Invalid update level')
 
     def evaluate_fitness(self, problem_function):
         """


### PR DESCRIPTION
I noticed that is missing the raise keyword to actually raise an error when the level is not valid. 